### PR TITLE
FOGL-9201 -  Protobuf message structure parsing fixes and in align with product data type

### DIFF
--- a/python/fledge/plugins/south/mqtt_sparkplug/mqtt_sparkplug.py
+++ b/python/fledge/plugins/south/mqtt_sparkplug/mqtt_sparkplug.py
@@ -242,31 +242,41 @@ def on_message(client, userdata, msg):
     global _assetName
     try:
         if _callback_event_loop is None:
-            _LOGGER.debug("Message processing event doesn't yet exist - creating new event loop.")
             asyncio.set_event_loop(asyncio.new_event_loop())
             _callback_event_loop = asyncio.get_event_loop()
         time_stamp = utils.local_timestamp()
         try:
-            string_data = msg.payload.decode('utf-8')
-            dict_data = json.loads(string_data)
+            data_str = msg.payload.decode('utf-8').replace('\n', '')
+            data_dict = json.loads(data_str)
             data = {
                 'asset': _assetName,
                 'timestamp': time_stamp,
-                'readings': dict_data if isinstance(dict_data, dict) else {"value": string_data}
+                'readings': data_dict if isinstance(data_dict, dict) else {"value": data_str}
             }
             _callback_event_loop.run_until_complete(save_data(data))
         except UnicodeDecodeError:
-            # Serialized data case with protobuf
-            inbound_payload = sparkplug_b_pb2.Payload()
-            inbound_payload.ParseFromString(msg.payload)
-            for metric in inbound_payload.metrics:
+            # Protobuf message structure
+            readings_list = sparkplug_b_pb2.ReadingsList()
+            readings_list.ParseFromString(msg.payload)
+            for reading in readings_list.readings:
+                # Initialize the structured data dictionary
                 data = {
-                    'asset': metric.name,
-                    'timestamp': time_stamp,  # metric.timestamp
-                    'readings': {
-                        "value": metric.float_value,
-                    }
+                    'asset': reading.asset,
+                    'timestamp': time_stamp, # reading.timestamp,
+                    'readings': {}
                 }
+                # Populate the readings dictionary
+                for reading_value in reading.readings:
+                    value = None
+                    if reading_value.HasField('value_double'):
+                        value = reading_value.value_double
+                    elif reading_value.HasField('value_int'):
+                        value = reading_value.value_int
+                    elif reading_value.HasField('value_string'):
+                        value = reading_value.value_string
+                    # TODO: FOGL- 9198 - Handle other data types
+                    # Add to the readings dictionary using the reading name as the key
+                    data['readings'][reading_value.name] = value
                 _callback_event_loop.run_until_complete(save_data(data))
         except Exception:
             # pass message payload as is
@@ -274,9 +284,10 @@ def on_message(client, userdata, msg):
                 'asset': _assetName,
                 'timestamp': time_stamp,
                 'readings': {
-                    "value": string_data,
+                    "value": data_str,
                 }
             }
             _callback_event_loop.run_until_complete(save_data(data))
     except Exception as e:
         _LOGGER.error(e)
+

--- a/python/fledge/plugins/south/mqtt_sparkplug/sparkplug_b/sparkplug_b.proto
+++ b/python/fledge/plugins/south/mqtt_sparkplug/sparkplug_b/sparkplug_b.proto
@@ -1,0 +1,27 @@
+syntax = "proto2";
+
+package sparkplug;
+
+// Message representing a reading from an asset
+message Reading {
+    required string asset = 1;                  // The name of the asset
+    repeated ReadingValue readings = 2;         // A list of readings
+    required string timestamp = 3;              // The timestamp in ISO 8601 format
+}
+
+// Message representing a single reading value
+message ReadingValue {
+    required string name = 1;                   // The name of the datapoint
+    oneof value {
+        string value_string = 2;                // Type - T_STRING For string values
+        uint64 value_int = 3;                   // Type - T_INTEGER For integer values
+        double value_double = 4;                // Type - T_FLOAT For double values
+        // TODO: FOGL- 9198 T_FLOAT_ARRAY, T_DP_DICT, T_DP_LIST, T_IMAGE, T_DATABUFFER
+    }
+}
+
+// Root message that could contain multiple readings
+message ReadingsList {
+    repeated Reading readings = 1;               // List of readings
+}
+

--- a/python/fledge/plugins/south/mqtt_sparkplug/sparkplug_b/sparkplug_b_pb2.py
+++ b/python/fledge/plugins/south/mqtt_sparkplug/sparkplug_b/sparkplug_b_pb2.py
@@ -2,8 +2,7 @@
 # source: sparkplug_b.proto
 
 import sys
-_b = sys.version_info[0] < 3 and (lambda x: x) or (lambda x: x.encode('latin1'))
-
+_b=sys.version_info[0]<3 and (lambda x:x) or (lambda x:x.encode('latin1'))
 from google.protobuf import descriptor as _descriptor
 from google.protobuf import message as _message
 from google.protobuf import reflection as _reflection
@@ -12,266 +11,53 @@ from google.protobuf import descriptor_pb2
 # @@protoc_insertion_point(imports)
 
 _sym_db = _symbol_database.Default()
+
+
+
+
 DESCRIPTOR = _descriptor.FileDescriptor(
   name='sparkplug_b.proto',
-  package='com.cirruslink.sparkplug.protobuf',
+  package='sparkplug',
   syntax='proto2',
-  serialized_pb=_b('\n\x11sparkplug_b.proto\x12!com.cirruslink.sparkplug.protobuf\"\xf6\x16\n\x07Payload\x12\x11\n\ttimestamp\x18\x01 \x01(\x04\x12\x42\n\x07metrics\x18\x02 \x03(\x0b\x32\x31.com.cirruslink.sparkplug.protobuf.Payload.Metric\x12\x0b\n\x03seq\x18\x03 \x01(\x04\x12\x0c\n\x04uuid\x18\x04 \x01(\t\x12\x0c\n\x04\x62ody\x18\x05 \x01(\x0c\x1a\xbe\x04\n\x08Template\x12\x0f\n\x07version\x18\x01 \x01(\t\x12\x42\n\x07metrics\x18\x02 \x03(\x0b\x32\x31.com.cirruslink.sparkplug.protobuf.Payload.Metric\x12Q\n\nparameters\x18\x03 \x03(\x0b\x32=.com.cirruslink.sparkplug.protobuf.Payload.Template.Parameter\x12\x14\n\x0ctemplate_ref\x18\x04 \x01(\t\x12\x15\n\ris_definition\x18\x05 \x01(\x08\x1a\xd2\x02\n\tParameter\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0c\n\x04type\x18\x02 \x01(\r\x12\x13\n\tint_value\x18\x03 \x01(\rH\x00\x12\x14\n\nlong_value\x18\x04 \x01(\x04H\x00\x12\x15\n\x0b\x66loat_value\x18\x05 \x01(\x02H\x00\x12\x16\n\x0c\x64ouble_value\x18\x06 \x01(\x01H\x00\x12\x17\n\rboolean_value\x18\x07 \x01(\x08H\x00\x12\x16\n\x0cstring_value\x18\x08 \x01(\tH\x00\x12p\n\x0f\x65xtension_value\x18\t \x01(\x0b\x32U.com.cirruslink.sparkplug.protobuf.Payload.Template.Parameter.ParameterValueExtensionH\x00\x1a#\n\x17ParameterValueExtension*\x08\x08\x01\x10\x80\x80\x80\x80\x02\x42\x07\n\x05value*\x08\x08\x06\x10\x80\x80\x80\x80\x02\x1a\xaf\x04\n\x07\x44\x61taSet\x12\x16\n\x0enum_of_columns\x18\x01 \x01(\x04\x12\x0f\n\x07\x63olumns\x18\x02 \x03(\t\x12\r\n\x05types\x18\x03 \x03(\r\x12\x44\n\x04rows\x18\x04 \x03(\x0b\x32\x36.com.cirruslink.sparkplug.protobuf.Payload.DataSet.Row\x1a\xb7\x02\n\x0c\x44\x61taSetValue\x12\x13\n\tint_value\x18\x01 \x01(\rH\x00\x12\x14\n\nlong_value\x18\x02 \x01(\x04H\x00\x12\x15\n\x0b\x66loat_value\x18\x03 \x01(\x02H\x00\x12\x16\n\x0c\x64ouble_value\x18\x04 \x01(\x01H\x00\x12\x17\n\rboolean_value\x18\x05 \x01(\x08H\x00\x12\x16\n\x0cstring_value\x18\x06 \x01(\tH\x00\x12p\n\x0f\x65xtension_value\x18\x07 \x01(\x0b\x32U.com.cirruslink.sparkplug.protobuf.Payload.DataSet.DataSetValue.DataSetValueExtensionH\x00\x1a!\n\x15\x44\x61taSetValueExtension*\x08\x08\x01\x10\x80\x80\x80\x80\x02\x42\x07\n\x05value\x1a\x62\n\x03Row\x12Q\n\x08\x65lements\x18\x01 \x03(\x0b\x32?.com.cirruslink.sparkplug.protobuf.Payload.DataSet.DataSetValue*\x08\x08\x02\x10\x80\x80\x80\x80\x02*\x08\x08\x05\x10\x80\x80\x80\x80\x02\x1a\x81\x04\n\rPropertyValue\x12\x0c\n\x04type\x18\x01 \x01(\r\x12\x0f\n\x07is_null\x18\x02 \x01(\x08\x12\x13\n\tint_value\x18\x03 \x01(\rH\x00\x12\x14\n\nlong_value\x18\x04 \x01(\x04H\x00\x12\x15\n\x0b\x66loat_value\x18\x05 \x01(\x02H\x00\x12\x16\n\x0c\x64ouble_value\x18\x06 \x01(\x01H\x00\x12\x17\n\rboolean_value\x18\x07 \x01(\x08H\x00\x12\x16\n\x0cstring_value\x18\x08 \x01(\tH\x00\x12S\n\x11propertyset_value\x18\t \x01(\x0b\x32\x36.com.cirruslink.sparkplug.protobuf.Payload.PropertySetH\x00\x12X\n\x12propertysets_value\x18\n \x01(\x0b\x32:.com.cirruslink.sparkplug.protobuf.Payload.PropertySetListH\x00\x12j\n\x0f\x65xtension_value\x18\x0b \x01(\x0b\x32O.com.cirruslink.sparkplug.protobuf.Payload.PropertyValue.PropertyValueExtensionH\x00\x1a\"\n\x16PropertyValueExtension*\x08\x08\x01\x10\x80\x80\x80\x80\x02\x42\x07\n\x05value\x1ao\n\x0bPropertySet\x12\x0c\n\x04keys\x18\x01 \x03(\t\x12H\n\x06values\x18\x02 \x03(\x0b\x32\x38.com.cirruslink.sparkplug.protobuf.Payload.PropertyValue*\x08\x08\x03\x10\x80\x80\x80\x80\x02\x1ah\n\x0fPropertySetList\x12K\n\x0bpropertyset\x18\x01 \x03(\x0b\x32\x36.com.cirruslink.sparkplug.protobuf.Payload.PropertySet*\x08\x08\x02\x10\x80\x80\x80\x80\x02\x1a\xa4\x01\n\x08MetaData\x12\x15\n\ris_multi_part\x18\x01 \x01(\x08\x12\x14\n\x0c\x63ontent_type\x18\x02 \x01(\t\x12\x0c\n\x04size\x18\x03 \x01(\x04\x12\x0b\n\x03seq\x18\x04 \x01(\x04\x12\x11\n\tfile_name\x18\x05 \x01(\t\x12\x11\n\tfile_type\x18\x06 \x01(\t\x12\x0b\n\x03md5\x18\x07 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x08 \x01(\t*\x08\x08\t\x10\x80\x80\x80\x80\x02\x1a\xe7\x05\n\x06Metric\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\r\n\x05\x61lias\x18\x02 \x01(\x04\x12\x11\n\ttimestamp\x18\x03 \x01(\x04\x12\x10\n\x08\x64\x61tatype\x18\x04 \x01(\r\x12\x15\n\ris_historical\x18\x05 \x01(\x08\x12\x14\n\x0cis_transient\x18\x06 \x01(\x08\x12\x0f\n\x07is_null\x18\x07 \x01(\x08\x12\x45\n\x08metadata\x18\x08 \x01(\x0b\x32\x33.com.cirruslink.sparkplug.protobuf.Payload.MetaData\x12J\n\nproperties\x18\t \x01(\x0b\x32\x36.com.cirruslink.sparkplug.protobuf.Payload.PropertySet\x12\x13\n\tint_value\x18\n \x01(\rH\x00\x12\x14\n\nlong_value\x18\x0b \x01(\x04H\x00\x12\x15\n\x0b\x66loat_value\x18\x0c \x01(\x02H\x00\x12\x16\n\x0c\x64ouble_value\x18\r \x01(\x01H\x00\x12\x17\n\rboolean_value\x18\x0e \x01(\x08H\x00\x12\x16\n\x0cstring_value\x18\x0f \x01(\tH\x00\x12\x15\n\x0b\x62ytes_value\x18\x10 \x01(\x0cH\x00\x12K\n\rdataset_value\x18\x11 \x01(\x0b\x32\x32.com.cirruslink.sparkplug.protobuf.Payload.DataSetH\x00\x12M\n\x0etemplate_value\x18\x12 \x01(\x0b\x32\x33.com.cirruslink.sparkplug.protobuf.Payload.TemplateH\x00\x12\x61\n\x0f\x65xtension_value\x18\x13 \x01(\x0b\x32\x46.com.cirruslink.sparkplug.protobuf.Payload.Metric.MetricValueExtensionH\x00\x1a \n\x14MetricValueExtension*\x08\x08\x01\x10\x80\x80\x80\x80\x02\x42\x07\n\x05value*\x08\x08\x06\x10\x80\x80\x80\x80\x02\x42\x34\n!com.cirruslink.sparkplug.protobufB\x0fSparkplugBProto')
+  serialized_pb=_b('\n\x11sparkplug_b.proto\x12\tsparkplug\"V\n\x07Reading\x12\r\n\x05\x61sset\x18\x01 \x02(\t\x12)\n\x08readings\x18\x02 \x03(\x0b\x32\x17.sparkplug.ReadingValue\x12\x11\n\ttimestamp\x18\x03 \x02(\t\"j\n\x0cReadingValue\x12\x0c\n\x04name\x18\x01 \x02(\t\x12\x16\n\x0cvalue_string\x18\x02 \x01(\tH\x00\x12\x13\n\tvalue_int\x18\x03 \x01(\x04H\x00\x12\x16\n\x0cvalue_double\x18\x04 \x01(\x01H\x00\x42\x07\n\x05value\"4\n\x0cReadingsList\x12$\n\x08readings\x18\x01 \x03(\x0b\x32\x12.sparkplug.Reading')
 )
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
-_PAYLOAD_TEMPLATE_PARAMETER_PARAMETERVALUEEXTENSION = _descriptor.Descriptor(
-  name='ParameterValueExtension',
-  full_name='com.cirruslink.sparkplug.protobuf.Payload.Template.Parameter.ParameterValueExtension',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  options=None,
-  is_extendable=True,
-  syntax='proto2',
-  extension_ranges=[(1, 536870912), ],
-  oneofs=[
-  ],
-  serialized_start=717,
-  serialized_end=752,
-)
 
-_PAYLOAD_TEMPLATE_PARAMETER = _descriptor.Descriptor(
-  name='Parameter',
-  full_name='com.cirruslink.sparkplug.protobuf.Payload.Template.Parameter',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='name', full_name='com.cirruslink.sparkplug.protobuf.Payload.Template.Parameter.name', index=0,
-      number=1, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='type', full_name='com.cirruslink.sparkplug.protobuf.Payload.Template.Parameter.type', index=1,
-      number=2, type=13, cpp_type=3, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='int_value', full_name='com.cirruslink.sparkplug.protobuf.Payload.Template.Parameter.int_value', index=2,
-      number=3, type=13, cpp_type=3, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='long_value', full_name='com.cirruslink.sparkplug.protobuf.Payload.Template.Parameter.long_value', index=3,
-      number=4, type=4, cpp_type=4, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='float_value', full_name='com.cirruslink.sparkplug.protobuf.Payload.Template.Parameter.float_value', index=4,
-      number=5, type=2, cpp_type=6, label=1,
-      has_default_value=False, default_value=float(0),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='double_value', full_name='com.cirruslink.sparkplug.protobuf.Payload.Template.Parameter.double_value', index=5,
-      number=6, type=1, cpp_type=5, label=1,
-      has_default_value=False, default_value=float(0),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='boolean_value', full_name='com.cirruslink.sparkplug.protobuf.Payload.Template.Parameter.boolean_value', index=6,
-      number=7, type=8, cpp_type=7, label=1,
-      has_default_value=False, default_value=False,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='string_value', full_name='com.cirruslink.sparkplug.protobuf.Payload.Template.Parameter.string_value', index=7,
-      number=8, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='extension_value', full_name='com.cirruslink.sparkplug.protobuf.Payload.Template.Parameter.extension_value', index=8,
-      number=9, type=11, cpp_type=10, label=1,
-      has_default_value=False, default_value=None,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-  ],
-  extensions=[
-  ],
-  nested_types=[_PAYLOAD_TEMPLATE_PARAMETER_PARAMETERVALUEEXTENSION, ],
-  enum_types=[
-  ],
-  options=None,
-  is_extendable=False,
-  syntax='proto2',
-  extension_ranges=[],
-  oneofs=[
-    _descriptor.OneofDescriptor(
-      name='value', full_name='com.cirruslink.sparkplug.protobuf.Payload.Template.Parameter.value',
-      index=0, containing_type=None, fields=[]),
-  ],
-  serialized_start=423,
-  serialized_end=761,
-)
 
-_PAYLOAD_TEMPLATE = _descriptor.Descriptor(
-  name='Template',
-  full_name='com.cirruslink.sparkplug.protobuf.Payload.Template',
+
+
+_READING = _descriptor.Descriptor(
+  name='Reading',
+  full_name='sparkplug.Reading',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='version', full_name='com.cirruslink.sparkplug.protobuf.Payload.Template.version', index=0,
-      number=1, type=9, cpp_type=9, label=1,
+      name='asset', full_name='sparkplug.Reading.asset', index=0,
+      number=1, type=9, cpp_type=9, label=2,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='metrics', full_name='com.cirruslink.sparkplug.protobuf.Payload.Template.metrics', index=1,
+      name='readings', full_name='sparkplug.Reading.readings', index=1,
       number=2, type=11, cpp_type=10, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='parameters', full_name='com.cirruslink.sparkplug.protobuf.Payload.Template.parameters', index=2,
-      number=3, type=11, cpp_type=10, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='template_ref', full_name='com.cirruslink.sparkplug.protobuf.Payload.Template.template_ref', index=3,
-      number=4, type=9, cpp_type=9, label=1,
+      name='timestamp', full_name='sparkplug.Reading.timestamp', index=2,
+      number=3, type=9, cpp_type=9, label=2,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
-    _descriptor.FieldDescriptor(
-      name='is_definition', full_name='com.cirruslink.sparkplug.protobuf.Payload.Template.is_definition', index=4,
-      number=5, type=8, cpp_type=7, label=1,
-      has_default_value=False, default_value=False,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-  ],
-  extensions=[
-  ],
-  nested_types=[_PAYLOAD_TEMPLATE_PARAMETER, ],
-  enum_types=[
-  ],
-  options=None,
-  is_extendable=True,
-  syntax='proto2',
-  extension_ranges=[(6, 536870912), ],
-  oneofs=[
-  ],
-  serialized_start=197,
-  serialized_end=771,
-)
-
-_PAYLOAD_DATASET_DATASETVALUE_DATASETVALUEEXTENSION = _descriptor.Descriptor(
-  name='DataSetValueExtension',
-  full_name='com.cirruslink.sparkplug.protobuf.Payload.DataSet.DataSetValue.DataSetValueExtension',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
   ],
   extensions=[
   ],
   nested_types=[],
-  enum_types=[
-  ],
-  options=None,
-  is_extendable=True,
-  syntax='proto2',
-  extension_ranges=[(1, 536870912), ],
-  oneofs=[
-  ],
-  serialized_start=1181,
-  serialized_end=1214,
-)
-
-_PAYLOAD_DATASET_DATASETVALUE = _descriptor.Descriptor(
-  name='DataSetValue',
-  full_name='com.cirruslink.sparkplug.protobuf.Payload.DataSet.DataSetValue',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='int_value', full_name='com.cirruslink.sparkplug.protobuf.Payload.DataSet.DataSetValue.int_value', index=0,
-      number=1, type=13, cpp_type=3, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='long_value', full_name='com.cirruslink.sparkplug.protobuf.Payload.DataSet.DataSetValue.long_value', index=1,
-      number=2, type=4, cpp_type=4, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='float_value', full_name='com.cirruslink.sparkplug.protobuf.Payload.DataSet.DataSetValue.float_value', index=2,
-      number=3, type=2, cpp_type=6, label=1,
-      has_default_value=False, default_value=float(0),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='double_value', full_name='com.cirruslink.sparkplug.protobuf.Payload.DataSet.DataSetValue.double_value', index=3,
-      number=4, type=1, cpp_type=5, label=1,
-      has_default_value=False, default_value=float(0),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='boolean_value', full_name='com.cirruslink.sparkplug.protobuf.Payload.DataSet.DataSetValue.boolean_value', index=4,
-      number=5, type=8, cpp_type=7, label=1,
-      has_default_value=False, default_value=False,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='string_value', full_name='com.cirruslink.sparkplug.protobuf.Payload.DataSet.DataSetValue.string_value', index=5,
-      number=6, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='extension_value', full_name='com.cirruslink.sparkplug.protobuf.Payload.DataSet.DataSetValue.extension_value', index=6,
-      number=7, type=11, cpp_type=10, label=1,
-      has_default_value=False, default_value=None,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-  ],
-  extensions=[
-  ],
-  nested_types=[_PAYLOAD_DATASET_DATASETVALUE_DATASETVALUEEXTENSION, ],
   enum_types=[
   ],
   options=None,
@@ -279,348 +65,44 @@ _PAYLOAD_DATASET_DATASETVALUE = _descriptor.Descriptor(
   syntax='proto2',
   extension_ranges=[],
   oneofs=[
-    _descriptor.OneofDescriptor(
-      name='value', full_name='com.cirruslink.sparkplug.protobuf.Payload.DataSet.DataSetValue.value',
-      index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=912,
-  serialized_end=1223,
+  serialized_start=32,
+  serialized_end=118,
 )
 
-_PAYLOAD_DATASET_ROW = _descriptor.Descriptor(
-  name='Row',
-  full_name='com.cirruslink.sparkplug.protobuf.Payload.DataSet.Row',
+
+_READINGVALUE = _descriptor.Descriptor(
+  name='ReadingValue',
+  full_name='sparkplug.ReadingValue',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='elements', full_name='com.cirruslink.sparkplug.protobuf.Payload.DataSet.Row.elements', index=0,
-      number=1, type=11, cpp_type=10, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  options=None,
-  is_extendable=True,
-  syntax='proto2',
-  extension_ranges=[(2, 536870912), ],
-  oneofs=[
-  ],
-  serialized_start=1225,
-  serialized_end=1323,
-)
-
-_PAYLOAD_DATASET = _descriptor.Descriptor(
-  name='DataSet',
-  full_name='com.cirruslink.sparkplug.protobuf.Payload.DataSet',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='num_of_columns', full_name='com.cirruslink.sparkplug.protobuf.Payload.DataSet.num_of_columns', index=0,
-      number=1, type=4, cpp_type=4, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='columns', full_name='com.cirruslink.sparkplug.protobuf.Payload.DataSet.columns', index=1,
-      number=2, type=9, cpp_type=9, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='types', full_name='com.cirruslink.sparkplug.protobuf.Payload.DataSet.types', index=2,
-      number=3, type=13, cpp_type=3, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='rows', full_name='com.cirruslink.sparkplug.protobuf.Payload.DataSet.rows', index=3,
-      number=4, type=11, cpp_type=10, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-  ],
-  extensions=[
-  ],
-  nested_types=[_PAYLOAD_DATASET_DATASETVALUE, _PAYLOAD_DATASET_ROW, ],
-  enum_types=[
-  ],
-  options=None,
-  is_extendable=True,
-  syntax='proto2',
-  extension_ranges=[(5, 536870912), ],
-  oneofs=[
-  ],
-  serialized_start=774,
-  serialized_end=1333,
-)
-
-_PAYLOAD_PROPERTYVALUE_PROPERTYVALUEEXTENSION = _descriptor.Descriptor(
-  name='PropertyValueExtension',
-  full_name='com.cirruslink.sparkplug.protobuf.Payload.PropertyValue.PropertyValueExtension',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  options=None,
-  is_extendable=True,
-  syntax='proto2',
-  extension_ranges=[(1, 536870912), ],
-  oneofs=[
-  ],
-  serialized_start=1806,
-  serialized_end=1840,
-)
-
-_PAYLOAD_PROPERTYVALUE = _descriptor.Descriptor(
-  name='PropertyValue',
-  full_name='com.cirruslink.sparkplug.protobuf.Payload.PropertyValue',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='type', full_name='com.cirruslink.sparkplug.protobuf.Payload.PropertyValue.type', index=0,
-      number=1, type=13, cpp_type=3, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='is_null', full_name='com.cirruslink.sparkplug.protobuf.Payload.PropertyValue.is_null', index=1,
-      number=2, type=8, cpp_type=7, label=1,
-      has_default_value=False, default_value=False,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='int_value', full_name='com.cirruslink.sparkplug.protobuf.Payload.PropertyValue.int_value', index=2,
-      number=3, type=13, cpp_type=3, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='long_value', full_name='com.cirruslink.sparkplug.protobuf.Payload.PropertyValue.long_value', index=3,
-      number=4, type=4, cpp_type=4, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='float_value', full_name='com.cirruslink.sparkplug.protobuf.Payload.PropertyValue.float_value', index=4,
-      number=5, type=2, cpp_type=6, label=1,
-      has_default_value=False, default_value=float(0),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='double_value', full_name='com.cirruslink.sparkplug.protobuf.Payload.PropertyValue.double_value', index=5,
-      number=6, type=1, cpp_type=5, label=1,
-      has_default_value=False, default_value=float(0),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='boolean_value', full_name='com.cirruslink.sparkplug.protobuf.Payload.PropertyValue.boolean_value', index=6,
-      number=7, type=8, cpp_type=7, label=1,
-      has_default_value=False, default_value=False,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='string_value', full_name='com.cirruslink.sparkplug.protobuf.Payload.PropertyValue.string_value', index=7,
-      number=8, type=9, cpp_type=9, label=1,
+      name='name', full_name='sparkplug.ReadingValue.name', index=0,
+      number=1, type=9, cpp_type=9, label=2,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='propertyset_value', full_name='com.cirruslink.sparkplug.protobuf.Payload.PropertyValue.propertyset_value', index=8,
-      number=9, type=11, cpp_type=10, label=1,
-      has_default_value=False, default_value=None,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='propertysets_value', full_name='com.cirruslink.sparkplug.protobuf.Payload.PropertyValue.propertysets_value', index=9,
-      number=10, type=11, cpp_type=10, label=1,
-      has_default_value=False, default_value=None,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='extension_value', full_name='com.cirruslink.sparkplug.protobuf.Payload.PropertyValue.extension_value', index=10,
-      number=11, type=11, cpp_type=10, label=1,
-      has_default_value=False, default_value=None,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-  ],
-  extensions=[
-  ],
-  nested_types=[_PAYLOAD_PROPERTYVALUE_PROPERTYVALUEEXTENSION, ],
-  enum_types=[
-  ],
-  options=None,
-  is_extendable=False,
-  syntax='proto2',
-  extension_ranges=[],
-  oneofs=[
-    _descriptor.OneofDescriptor(
-      name='value', full_name='com.cirruslink.sparkplug.protobuf.Payload.PropertyValue.value',
-      index=0, containing_type=None, fields=[]),
-  ],
-  serialized_start=1336,
-  serialized_end=1849,
-)
-
-_PAYLOAD_PROPERTYSET = _descriptor.Descriptor(
-  name='PropertySet',
-  full_name='com.cirruslink.sparkplug.protobuf.Payload.PropertySet',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='keys', full_name='com.cirruslink.sparkplug.protobuf.Payload.PropertySet.keys', index=0,
-      number=1, type=9, cpp_type=9, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='values', full_name='com.cirruslink.sparkplug.protobuf.Payload.PropertySet.values', index=1,
-      number=2, type=11, cpp_type=10, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  options=None,
-  is_extendable=True,
-  syntax='proto2',
-  extension_ranges=[(3, 536870912), ],
-  oneofs=[
-  ],
-  serialized_start=1851,
-  serialized_end=1962,
-)
-
-_PAYLOAD_PROPERTYSETLIST = _descriptor.Descriptor(
-  name='PropertySetList',
-  full_name='com.cirruslink.sparkplug.protobuf.Payload.PropertySetList',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='propertyset', full_name='com.cirruslink.sparkplug.protobuf.Payload.PropertySetList.propertyset', index=0,
-      number=1, type=11, cpp_type=10, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  options=None,
-  is_extendable=True,
-  syntax='proto2',
-  extension_ranges=[(2, 536870912), ],
-  oneofs=[
-  ],
-  serialized_start=1964,
-  serialized_end=2068,
-)
-
-_PAYLOAD_METADATA = _descriptor.Descriptor(
-  name='MetaData',
-  full_name='com.cirruslink.sparkplug.protobuf.Payload.MetaData',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='is_multi_part', full_name='com.cirruslink.sparkplug.protobuf.Payload.MetaData.is_multi_part', index=0,
-      number=1, type=8, cpp_type=7, label=1,
-      has_default_value=False, default_value=False,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='content_type', full_name='com.cirruslink.sparkplug.protobuf.Payload.MetaData.content_type', index=1,
+      name='value_string', full_name='sparkplug.ReadingValue.value_string', index=1,
       number=2, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='size', full_name='com.cirruslink.sparkplug.protobuf.Payload.MetaData.size', index=2,
+      name='value_int', full_name='sparkplug.ReadingValue.value_int', index=2,
       number=3, type=4, cpp_type=4, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='seq', full_name='com.cirruslink.sparkplug.protobuf.Payload.MetaData.seq', index=3,
-      number=4, type=4, cpp_type=4, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='file_name', full_name='com.cirruslink.sparkplug.protobuf.Payload.MetaData.file_name', index=4,
-      number=5, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='file_type', full_name='com.cirruslink.sparkplug.protobuf.Payload.MetaData.file_type', index=5,
-      number=6, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='md5', full_name='com.cirruslink.sparkplug.protobuf.Payload.MetaData.md5', index=6,
-      number=7, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='description', full_name='com.cirruslink.sparkplug.protobuf.Payload.MetaData.description', index=7,
-      number=8, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
+      name='value_double', full_name='sparkplug.ReadingValue.value_double', index=3,
+      number=4, type=1, cpp_type=5, label=1,
+      has_default_value=False, default_value=float(0),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
@@ -628,185 +110,6 @@ _PAYLOAD_METADATA = _descriptor.Descriptor(
   extensions=[
   ],
   nested_types=[],
-  enum_types=[
-  ],
-  options=None,
-  is_extendable=True,
-  syntax='proto2',
-  extension_ranges=[(9, 536870912), ],
-  oneofs=[
-  ],
-  serialized_start=2071,
-  serialized_end=2235,
-)
-
-_PAYLOAD_METRIC_METRICVALUEEXTENSION = _descriptor.Descriptor(
-  name='MetricValueExtension',
-  full_name='com.cirruslink.sparkplug.protobuf.Payload.Metric.MetricValueExtension',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  options=None,
-  is_extendable=True,
-  syntax='proto2',
-  extension_ranges=[(1, 536870912), ],
-  oneofs=[
-  ],
-  serialized_start=2940,
-  serialized_end=2972,
-)
-
-_PAYLOAD_METRIC = _descriptor.Descriptor(
-  name='Metric',
-  full_name='com.cirruslink.sparkplug.protobuf.Payload.Metric',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='name', full_name='com.cirruslink.sparkplug.protobuf.Payload.Metric.name', index=0,
-      number=1, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='alias', full_name='com.cirruslink.sparkplug.protobuf.Payload.Metric.alias', index=1,
-      number=2, type=4, cpp_type=4, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='timestamp', full_name='com.cirruslink.sparkplug.protobuf.Payload.Metric.timestamp', index=2,
-      number=3, type=4, cpp_type=4, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='datatype', full_name='com.cirruslink.sparkplug.protobuf.Payload.Metric.datatype', index=3,
-      number=4, type=13, cpp_type=3, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='is_historical', full_name='com.cirruslink.sparkplug.protobuf.Payload.Metric.is_historical', index=4,
-      number=5, type=8, cpp_type=7, label=1,
-      has_default_value=False, default_value=False,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='is_transient', full_name='com.cirruslink.sparkplug.protobuf.Payload.Metric.is_transient', index=5,
-      number=6, type=8, cpp_type=7, label=1,
-      has_default_value=False, default_value=False,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='is_null', full_name='com.cirruslink.sparkplug.protobuf.Payload.Metric.is_null', index=6,
-      number=7, type=8, cpp_type=7, label=1,
-      has_default_value=False, default_value=False,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='metadata', full_name='com.cirruslink.sparkplug.protobuf.Payload.Metric.metadata', index=7,
-      number=8, type=11, cpp_type=10, label=1,
-      has_default_value=False, default_value=None,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='properties', full_name='com.cirruslink.sparkplug.protobuf.Payload.Metric.properties', index=8,
-      number=9, type=11, cpp_type=10, label=1,
-      has_default_value=False, default_value=None,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='int_value', full_name='com.cirruslink.sparkplug.protobuf.Payload.Metric.int_value', index=9,
-      number=10, type=13, cpp_type=3, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='long_value', full_name='com.cirruslink.sparkplug.protobuf.Payload.Metric.long_value', index=10,
-      number=11, type=4, cpp_type=4, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='float_value', full_name='com.cirruslink.sparkplug.protobuf.Payload.Metric.float_value', index=11,
-      number=12, type=2, cpp_type=6, label=1,
-      has_default_value=False, default_value=float(0),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='double_value', full_name='com.cirruslink.sparkplug.protobuf.Payload.Metric.double_value', index=12,
-      number=13, type=1, cpp_type=5, label=1,
-      has_default_value=False, default_value=float(0),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='boolean_value', full_name='com.cirruslink.sparkplug.protobuf.Payload.Metric.boolean_value', index=13,
-      number=14, type=8, cpp_type=7, label=1,
-      has_default_value=False, default_value=False,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='string_value', full_name='com.cirruslink.sparkplug.protobuf.Payload.Metric.string_value', index=14,
-      number=15, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='bytes_value', full_name='com.cirruslink.sparkplug.protobuf.Payload.Metric.bytes_value', index=15,
-      number=16, type=12, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b(""),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='dataset_value', full_name='com.cirruslink.sparkplug.protobuf.Payload.Metric.dataset_value', index=16,
-      number=17, type=11, cpp_type=10, label=1,
-      has_default_value=False, default_value=None,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='template_value', full_name='com.cirruslink.sparkplug.protobuf.Payload.Metric.template_value', index=17,
-      number=18, type=11, cpp_type=10, label=1,
-      has_default_value=False, default_value=None,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='extension_value', full_name='com.cirruslink.sparkplug.protobuf.Payload.Metric.extension_value', index=18,
-      number=19, type=11, cpp_type=10, label=1,
-      has_default_value=False, default_value=None,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-  ],
-  extensions=[
-  ],
-  nested_types=[_PAYLOAD_METRIC_METRICVALUEEXTENSION, ],
   enum_types=[
   ],
   options=None,
@@ -815,323 +118,79 @@ _PAYLOAD_METRIC = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
     _descriptor.OneofDescriptor(
-      name='value', full_name='com.cirruslink.sparkplug.protobuf.Payload.Metric.value',
+      name='value', full_name='sparkplug.ReadingValue.value',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=2238,
-  serialized_end=2981,
+  serialized_start=120,
+  serialized_end=226,
 )
 
-_PAYLOAD = _descriptor.Descriptor(
-  name='Payload',
-  full_name='com.cirruslink.sparkplug.protobuf.Payload',
+
+_READINGSLIST = _descriptor.Descriptor(
+  name='ReadingsList',
+  full_name='sparkplug.ReadingsList',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='timestamp', full_name='com.cirruslink.sparkplug.protobuf.Payload.timestamp', index=0,
-      number=1, type=4, cpp_type=4, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='metrics', full_name='com.cirruslink.sparkplug.protobuf.Payload.metrics', index=1,
-      number=2, type=11, cpp_type=10, label=3,
+      name='readings', full_name='sparkplug.ReadingsList.readings', index=0,
+      number=1, type=11, cpp_type=10, label=3,
       has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='seq', full_name='com.cirruslink.sparkplug.protobuf.Payload.seq', index=2,
-      number=3, type=4, cpp_type=4, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='uuid', full_name='com.cirruslink.sparkplug.protobuf.Payload.uuid', index=3,
-      number=4, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='body', full_name='com.cirruslink.sparkplug.protobuf.Payload.body', index=4,
-      number=5, type=12, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b(""),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
   ],
   extensions=[
   ],
-  nested_types=[_PAYLOAD_TEMPLATE, _PAYLOAD_DATASET, _PAYLOAD_PROPERTYVALUE, _PAYLOAD_PROPERTYSET, _PAYLOAD_PROPERTYSETLIST, _PAYLOAD_METADATA, _PAYLOAD_METRIC, ],
+  nested_types=[],
   enum_types=[
   ],
   options=None,
-  is_extendable=True,
+  is_extendable=False,
   syntax='proto2',
-  extension_ranges=[(6, 536870912), ],
+  extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=57,
-  serialized_end=2991,
+  serialized_start=228,
+  serialized_end=280,
 )
 
-_PAYLOAD_TEMPLATE_PARAMETER_PARAMETERVALUEEXTENSION.containing_type = _PAYLOAD_TEMPLATE_PARAMETER
-_PAYLOAD_TEMPLATE_PARAMETER.fields_by_name['extension_value'].message_type = _PAYLOAD_TEMPLATE_PARAMETER_PARAMETERVALUEEXTENSION
-_PAYLOAD_TEMPLATE_PARAMETER.containing_type = _PAYLOAD_TEMPLATE
-_PAYLOAD_TEMPLATE_PARAMETER.oneofs_by_name['value'].fields.append(
-  _PAYLOAD_TEMPLATE_PARAMETER.fields_by_name['int_value'])
-_PAYLOAD_TEMPLATE_PARAMETER.fields_by_name['int_value'].containing_oneof = _PAYLOAD_TEMPLATE_PARAMETER.oneofs_by_name['value']
-_PAYLOAD_TEMPLATE_PARAMETER.oneofs_by_name['value'].fields.append(
-  _PAYLOAD_TEMPLATE_PARAMETER.fields_by_name['long_value'])
-_PAYLOAD_TEMPLATE_PARAMETER.fields_by_name['long_value'].containing_oneof = _PAYLOAD_TEMPLATE_PARAMETER.oneofs_by_name['value']
-_PAYLOAD_TEMPLATE_PARAMETER.oneofs_by_name['value'].fields.append(
-  _PAYLOAD_TEMPLATE_PARAMETER.fields_by_name['float_value'])
-_PAYLOAD_TEMPLATE_PARAMETER.fields_by_name['float_value'].containing_oneof = _PAYLOAD_TEMPLATE_PARAMETER.oneofs_by_name['value']
-_PAYLOAD_TEMPLATE_PARAMETER.oneofs_by_name['value'].fields.append(
-  _PAYLOAD_TEMPLATE_PARAMETER.fields_by_name['double_value'])
-_PAYLOAD_TEMPLATE_PARAMETER.fields_by_name['double_value'].containing_oneof = _PAYLOAD_TEMPLATE_PARAMETER.oneofs_by_name['value']
-_PAYLOAD_TEMPLATE_PARAMETER.oneofs_by_name['value'].fields.append(
-  _PAYLOAD_TEMPLATE_PARAMETER.fields_by_name['boolean_value'])
-_PAYLOAD_TEMPLATE_PARAMETER.fields_by_name['boolean_value'].containing_oneof = _PAYLOAD_TEMPLATE_PARAMETER.oneofs_by_name['value']
-_PAYLOAD_TEMPLATE_PARAMETER.oneofs_by_name['value'].fields.append(
-  _PAYLOAD_TEMPLATE_PARAMETER.fields_by_name['string_value'])
-_PAYLOAD_TEMPLATE_PARAMETER.fields_by_name['string_value'].containing_oneof = _PAYLOAD_TEMPLATE_PARAMETER.oneofs_by_name['value']
-_PAYLOAD_TEMPLATE_PARAMETER.oneofs_by_name['value'].fields.append(
-  _PAYLOAD_TEMPLATE_PARAMETER.fields_by_name['extension_value'])
-_PAYLOAD_TEMPLATE_PARAMETER.fields_by_name['extension_value'].containing_oneof = _PAYLOAD_TEMPLATE_PARAMETER.oneofs_by_name['value']
-_PAYLOAD_TEMPLATE.fields_by_name['metrics'].message_type = _PAYLOAD_METRIC
-_PAYLOAD_TEMPLATE.fields_by_name['parameters'].message_type = _PAYLOAD_TEMPLATE_PARAMETER
-_PAYLOAD_TEMPLATE.containing_type = _PAYLOAD
-_PAYLOAD_DATASET_DATASETVALUE_DATASETVALUEEXTENSION.containing_type = _PAYLOAD_DATASET_DATASETVALUE
-_PAYLOAD_DATASET_DATASETVALUE.fields_by_name['extension_value'].message_type = _PAYLOAD_DATASET_DATASETVALUE_DATASETVALUEEXTENSION
-_PAYLOAD_DATASET_DATASETVALUE.containing_type = _PAYLOAD_DATASET
-_PAYLOAD_DATASET_DATASETVALUE.oneofs_by_name['value'].fields.append(
-  _PAYLOAD_DATASET_DATASETVALUE.fields_by_name['int_value'])
-_PAYLOAD_DATASET_DATASETVALUE.fields_by_name['int_value'].containing_oneof = _PAYLOAD_DATASET_DATASETVALUE.oneofs_by_name['value']
-_PAYLOAD_DATASET_DATASETVALUE.oneofs_by_name['value'].fields.append(
-  _PAYLOAD_DATASET_DATASETVALUE.fields_by_name['long_value'])
-_PAYLOAD_DATASET_DATASETVALUE.fields_by_name['long_value'].containing_oneof = _PAYLOAD_DATASET_DATASETVALUE.oneofs_by_name['value']
-_PAYLOAD_DATASET_DATASETVALUE.oneofs_by_name['value'].fields.append(
-  _PAYLOAD_DATASET_DATASETVALUE.fields_by_name['float_value'])
-_PAYLOAD_DATASET_DATASETVALUE.fields_by_name['float_value'].containing_oneof = _PAYLOAD_DATASET_DATASETVALUE.oneofs_by_name['value']
-_PAYLOAD_DATASET_DATASETVALUE.oneofs_by_name['value'].fields.append(
-  _PAYLOAD_DATASET_DATASETVALUE.fields_by_name['double_value'])
-_PAYLOAD_DATASET_DATASETVALUE.fields_by_name['double_value'].containing_oneof = _PAYLOAD_DATASET_DATASETVALUE.oneofs_by_name['value']
-_PAYLOAD_DATASET_DATASETVALUE.oneofs_by_name['value'].fields.append(
-  _PAYLOAD_DATASET_DATASETVALUE.fields_by_name['boolean_value'])
-_PAYLOAD_DATASET_DATASETVALUE.fields_by_name['boolean_value'].containing_oneof = _PAYLOAD_DATASET_DATASETVALUE.oneofs_by_name['value']
-_PAYLOAD_DATASET_DATASETVALUE.oneofs_by_name['value'].fields.append(
-  _PAYLOAD_DATASET_DATASETVALUE.fields_by_name['string_value'])
-_PAYLOAD_DATASET_DATASETVALUE.fields_by_name['string_value'].containing_oneof = _PAYLOAD_DATASET_DATASETVALUE.oneofs_by_name['value']
-_PAYLOAD_DATASET_DATASETVALUE.oneofs_by_name['value'].fields.append(
-  _PAYLOAD_DATASET_DATASETVALUE.fields_by_name['extension_value'])
-_PAYLOAD_DATASET_DATASETVALUE.fields_by_name['extension_value'].containing_oneof = _PAYLOAD_DATASET_DATASETVALUE.oneofs_by_name['value']
-_PAYLOAD_DATASET_ROW.fields_by_name['elements'].message_type = _PAYLOAD_DATASET_DATASETVALUE
-_PAYLOAD_DATASET_ROW.containing_type = _PAYLOAD_DATASET
-_PAYLOAD_DATASET.fields_by_name['rows'].message_type = _PAYLOAD_DATASET_ROW
-_PAYLOAD_DATASET.containing_type = _PAYLOAD
-_PAYLOAD_PROPERTYVALUE_PROPERTYVALUEEXTENSION.containing_type = _PAYLOAD_PROPERTYVALUE
-_PAYLOAD_PROPERTYVALUE.fields_by_name['propertyset_value'].message_type = _PAYLOAD_PROPERTYSET
-_PAYLOAD_PROPERTYVALUE.fields_by_name['propertysets_value'].message_type = _PAYLOAD_PROPERTYSETLIST
-_PAYLOAD_PROPERTYVALUE.fields_by_name['extension_value'].message_type = _PAYLOAD_PROPERTYVALUE_PROPERTYVALUEEXTENSION
-_PAYLOAD_PROPERTYVALUE.containing_type = _PAYLOAD
-_PAYLOAD_PROPERTYVALUE.oneofs_by_name['value'].fields.append(
-  _PAYLOAD_PROPERTYVALUE.fields_by_name['int_value'])
-_PAYLOAD_PROPERTYVALUE.fields_by_name['int_value'].containing_oneof = _PAYLOAD_PROPERTYVALUE.oneofs_by_name['value']
-_PAYLOAD_PROPERTYVALUE.oneofs_by_name['value'].fields.append(
-  _PAYLOAD_PROPERTYVALUE.fields_by_name['long_value'])
-_PAYLOAD_PROPERTYVALUE.fields_by_name['long_value'].containing_oneof = _PAYLOAD_PROPERTYVALUE.oneofs_by_name['value']
-_PAYLOAD_PROPERTYVALUE.oneofs_by_name['value'].fields.append(
-  _PAYLOAD_PROPERTYVALUE.fields_by_name['float_value'])
-_PAYLOAD_PROPERTYVALUE.fields_by_name['float_value'].containing_oneof = _PAYLOAD_PROPERTYVALUE.oneofs_by_name['value']
-_PAYLOAD_PROPERTYVALUE.oneofs_by_name['value'].fields.append(
-  _PAYLOAD_PROPERTYVALUE.fields_by_name['double_value'])
-_PAYLOAD_PROPERTYVALUE.fields_by_name['double_value'].containing_oneof = _PAYLOAD_PROPERTYVALUE.oneofs_by_name['value']
-_PAYLOAD_PROPERTYVALUE.oneofs_by_name['value'].fields.append(
-  _PAYLOAD_PROPERTYVALUE.fields_by_name['boolean_value'])
-_PAYLOAD_PROPERTYVALUE.fields_by_name['boolean_value'].containing_oneof = _PAYLOAD_PROPERTYVALUE.oneofs_by_name['value']
-_PAYLOAD_PROPERTYVALUE.oneofs_by_name['value'].fields.append(
-  _PAYLOAD_PROPERTYVALUE.fields_by_name['string_value'])
-_PAYLOAD_PROPERTYVALUE.fields_by_name['string_value'].containing_oneof = _PAYLOAD_PROPERTYVALUE.oneofs_by_name['value']
-_PAYLOAD_PROPERTYVALUE.oneofs_by_name['value'].fields.append(
-  _PAYLOAD_PROPERTYVALUE.fields_by_name['propertyset_value'])
-_PAYLOAD_PROPERTYVALUE.fields_by_name['propertyset_value'].containing_oneof = _PAYLOAD_PROPERTYVALUE.oneofs_by_name['value']
-_PAYLOAD_PROPERTYVALUE.oneofs_by_name['value'].fields.append(
-  _PAYLOAD_PROPERTYVALUE.fields_by_name['propertysets_value'])
-_PAYLOAD_PROPERTYVALUE.fields_by_name['propertysets_value'].containing_oneof = _PAYLOAD_PROPERTYVALUE.oneofs_by_name['value']
-_PAYLOAD_PROPERTYVALUE.oneofs_by_name['value'].fields.append(
-  _PAYLOAD_PROPERTYVALUE.fields_by_name['extension_value'])
-_PAYLOAD_PROPERTYVALUE.fields_by_name['extension_value'].containing_oneof = _PAYLOAD_PROPERTYVALUE.oneofs_by_name['value']
-_PAYLOAD_PROPERTYSET.fields_by_name['values'].message_type = _PAYLOAD_PROPERTYVALUE
-_PAYLOAD_PROPERTYSET.containing_type = _PAYLOAD
-_PAYLOAD_PROPERTYSETLIST.fields_by_name['propertyset'].message_type = _PAYLOAD_PROPERTYSET
-_PAYLOAD_PROPERTYSETLIST.containing_type = _PAYLOAD
-_PAYLOAD_METADATA.containing_type = _PAYLOAD
-_PAYLOAD_METRIC_METRICVALUEEXTENSION.containing_type = _PAYLOAD_METRIC
-_PAYLOAD_METRIC.fields_by_name['metadata'].message_type = _PAYLOAD_METADATA
-_PAYLOAD_METRIC.fields_by_name['properties'].message_type = _PAYLOAD_PROPERTYSET
-_PAYLOAD_METRIC.fields_by_name['dataset_value'].message_type = _PAYLOAD_DATASET
-_PAYLOAD_METRIC.fields_by_name['template_value'].message_type = _PAYLOAD_TEMPLATE
-_PAYLOAD_METRIC.fields_by_name['extension_value'].message_type = _PAYLOAD_METRIC_METRICVALUEEXTENSION
-_PAYLOAD_METRIC.containing_type = _PAYLOAD
-_PAYLOAD_METRIC.oneofs_by_name['value'].fields.append(
-  _PAYLOAD_METRIC.fields_by_name['int_value'])
-_PAYLOAD_METRIC.fields_by_name['int_value'].containing_oneof = _PAYLOAD_METRIC.oneofs_by_name['value']
-_PAYLOAD_METRIC.oneofs_by_name['value'].fields.append(
-  _PAYLOAD_METRIC.fields_by_name['long_value'])
-_PAYLOAD_METRIC.fields_by_name['long_value'].containing_oneof = _PAYLOAD_METRIC.oneofs_by_name['value']
-_PAYLOAD_METRIC.oneofs_by_name['value'].fields.append(
-  _PAYLOAD_METRIC.fields_by_name['float_value'])
-_PAYLOAD_METRIC.fields_by_name['float_value'].containing_oneof = _PAYLOAD_METRIC.oneofs_by_name['value']
-_PAYLOAD_METRIC.oneofs_by_name['value'].fields.append(
-  _PAYLOAD_METRIC.fields_by_name['double_value'])
-_PAYLOAD_METRIC.fields_by_name['double_value'].containing_oneof = _PAYLOAD_METRIC.oneofs_by_name['value']
-_PAYLOAD_METRIC.oneofs_by_name['value'].fields.append(
-  _PAYLOAD_METRIC.fields_by_name['boolean_value'])
-_PAYLOAD_METRIC.fields_by_name['boolean_value'].containing_oneof = _PAYLOAD_METRIC.oneofs_by_name['value']
-_PAYLOAD_METRIC.oneofs_by_name['value'].fields.append(
-  _PAYLOAD_METRIC.fields_by_name['string_value'])
-_PAYLOAD_METRIC.fields_by_name['string_value'].containing_oneof = _PAYLOAD_METRIC.oneofs_by_name['value']
-_PAYLOAD_METRIC.oneofs_by_name['value'].fields.append(
-  _PAYLOAD_METRIC.fields_by_name['bytes_value'])
-_PAYLOAD_METRIC.fields_by_name['bytes_value'].containing_oneof = _PAYLOAD_METRIC.oneofs_by_name['value']
-_PAYLOAD_METRIC.oneofs_by_name['value'].fields.append(
-  _PAYLOAD_METRIC.fields_by_name['dataset_value'])
-_PAYLOAD_METRIC.fields_by_name['dataset_value'].containing_oneof = _PAYLOAD_METRIC.oneofs_by_name['value']
-_PAYLOAD_METRIC.oneofs_by_name['value'].fields.append(
-  _PAYLOAD_METRIC.fields_by_name['template_value'])
-_PAYLOAD_METRIC.fields_by_name['template_value'].containing_oneof = _PAYLOAD_METRIC.oneofs_by_name['value']
-_PAYLOAD_METRIC.oneofs_by_name['value'].fields.append(
-  _PAYLOAD_METRIC.fields_by_name['extension_value'])
-_PAYLOAD_METRIC.fields_by_name['extension_value'].containing_oneof = _PAYLOAD_METRIC.oneofs_by_name['value']
-_PAYLOAD.fields_by_name['metrics'].message_type = _PAYLOAD_METRIC
-DESCRIPTOR.message_types_by_name['Payload'] = _PAYLOAD
+_READING.fields_by_name['readings'].message_type = _READINGVALUE
+_READINGVALUE.oneofs_by_name['value'].fields.append(
+  _READINGVALUE.fields_by_name['value_string'])
+_READINGVALUE.fields_by_name['value_string'].containing_oneof = _READINGVALUE.oneofs_by_name['value']
+_READINGVALUE.oneofs_by_name['value'].fields.append(
+  _READINGVALUE.fields_by_name['value_int'])
+_READINGVALUE.fields_by_name['value_int'].containing_oneof = _READINGVALUE.oneofs_by_name['value']
+_READINGVALUE.oneofs_by_name['value'].fields.append(
+  _READINGVALUE.fields_by_name['value_double'])
+_READINGVALUE.fields_by_name['value_double'].containing_oneof = _READINGVALUE.oneofs_by_name['value']
+_READINGSLIST.fields_by_name['readings'].message_type = _READING
+DESCRIPTOR.message_types_by_name['Reading'] = _READING
+DESCRIPTOR.message_types_by_name['ReadingValue'] = _READINGVALUE
+DESCRIPTOR.message_types_by_name['ReadingsList'] = _READINGSLIST
 
-Payload = _reflection.GeneratedProtocolMessageType('Payload', (_message.Message,), dict(
-
-  Template=_reflection.GeneratedProtocolMessageType('Template', (_message.Message,), dict(
-
-    Parameter=_reflection.GeneratedProtocolMessageType('Parameter', (_message.Message,), dict(
-
-      ParameterValueExtension=_reflection.GeneratedProtocolMessageType('ParameterValueExtension', (_message.Message,), dict(
-        DESCRIPTOR=_PAYLOAD_TEMPLATE_PARAMETER_PARAMETERVALUEEXTENSION,
-        __module__='sparkplug_b_pb2'
-        # @@protoc_insertion_point(class_scope:com.cirruslink.sparkplug.protobuf.Payload.Template.Parameter.ParameterValueExtension)
-        ))
-      ,
-      DESCRIPTOR=_PAYLOAD_TEMPLATE_PARAMETER,
-      __module__='sparkplug_b_pb2'
-      # @@protoc_insertion_point(class_scope:com.cirruslink.sparkplug.protobuf.Payload.Template.Parameter)
-      ))
-    ,
-    DESCRIPTOR=_PAYLOAD_TEMPLATE,
-    __module__='sparkplug_b_pb2'
-    # @@protoc_insertion_point(class_scope:com.cirruslink.sparkplug.protobuf.Payload.Template)
-    ))
-  ,
-
-  DataSet=_reflection.GeneratedProtocolMessageType('DataSet', (_message.Message,), dict(
-
-    DataSetValue=_reflection.GeneratedProtocolMessageType('DataSetValue', (_message.Message,), dict(
-
-      DataSetValueExtension=_reflection.GeneratedProtocolMessageType('DataSetValueExtension', (_message.Message,), dict(
-        DESCRIPTOR=_PAYLOAD_DATASET_DATASETVALUE_DATASETVALUEEXTENSION,
-        __module__='sparkplug_b_pb2'
-        # @@protoc_insertion_point(class_scope:com.cirruslink.sparkplug.protobuf.Payload.DataSet.DataSetValue.DataSetValueExtension)
-        ))
-      ,
-      DESCRIPTOR=_PAYLOAD_DATASET_DATASETVALUE,
-      __module__='sparkplug_b_pb2'
-      # @@protoc_insertion_point(class_scope:com.cirruslink.sparkplug.protobuf.Payload.DataSet.DataSetValue)
-      ))
-    ,
-
-    Row=_reflection.GeneratedProtocolMessageType('Row', (_message.Message,), dict(
-      DESCRIPTOR=_PAYLOAD_DATASET_ROW,
-      __module__='sparkplug_b_pb2'
-      # @@protoc_insertion_point(class_scope:com.cirruslink.sparkplug.protobuf.Payload.DataSet.Row)
-      ))
-    ,
-    DESCRIPTOR=_PAYLOAD_DATASET,
-    __module__='sparkplug_b_pb2'
-    # @@protoc_insertion_point(class_scope:com.cirruslink.sparkplug.protobuf.Payload.DataSet)
-    ))
-  ,
-
-  PropertyValue=_reflection.GeneratedProtocolMessageType('PropertyValue', (_message.Message,), dict(
-
-    PropertyValueExtension=_reflection.GeneratedProtocolMessageType('PropertyValueExtension', (_message.Message,), dict(
-      DESCRIPTOR=_PAYLOAD_PROPERTYVALUE_PROPERTYVALUEEXTENSION,
-      __module__='sparkplug_b_pb2'
-      # @@protoc_insertion_point(class_scope:com.cirruslink.sparkplug.protobuf.Payload.PropertyValue.PropertyValueExtension)
-      ))
-    ,
-    DESCRIPTOR=_PAYLOAD_PROPERTYVALUE,
-    __module__='sparkplug_b_pb2'
-    # @@protoc_insertion_point(class_scope:com.cirruslink.sparkplug.protobuf.Payload.PropertyValue)
-    ))
-  ,
-
-  PropertySet=_reflection.GeneratedProtocolMessageType('PropertySet', (_message.Message,), dict(
-    DESCRIPTOR=_PAYLOAD_PROPERTYSET,
-    __module__='sparkplug_b_pb2'
-    # @@protoc_insertion_point(class_scope:com.cirruslink.sparkplug.protobuf.Payload.PropertySet)
-    ))
-  ,
-
-  PropertySetList=_reflection.GeneratedProtocolMessageType('PropertySetList', (_message.Message,), dict(
-    DESCRIPTOR=_PAYLOAD_PROPERTYSETLIST,
-    __module__='sparkplug_b_pb2'
-    # @@protoc_insertion_point(class_scope:com.cirruslink.sparkplug.protobuf.Payload.PropertySetList)
-    ))
-  ,
-
-  MetaData=_reflection.GeneratedProtocolMessageType('MetaData', (_message.Message,), dict(
-    DESCRIPTOR=_PAYLOAD_METADATA,
-    __module__='sparkplug_b_pb2'
-    # @@protoc_insertion_point(class_scope:com.cirruslink.sparkplug.protobuf.Payload.MetaData)
-    ))
-  ,
-
-  Metric=_reflection.GeneratedProtocolMessageType('Metric', (_message.Message,), dict(
-
-    MetricValueExtension=_reflection.GeneratedProtocolMessageType('MetricValueExtension', (_message.Message,), dict(
-      DESCRIPTOR=_PAYLOAD_METRIC_METRICVALUEEXTENSION,
-      __module__='sparkplug_b_pb2'
-      # @@protoc_insertion_point(class_scope:com.cirruslink.sparkplug.protobuf.Payload.Metric.MetricValueExtension)
-      ))
-    ,
-    DESCRIPTOR=_PAYLOAD_METRIC,
-    __module__='sparkplug_b_pb2'
-    # @@protoc_insertion_point(class_scope:com.cirruslink.sparkplug.protobuf.Payload.Metric)
-    ))
-  ,
-  DESCRIPTOR=_PAYLOAD,
-  __module__='sparkplug_b_pb2'
-  # @@protoc_insertion_point(class_scope:com.cirruslink.sparkplug.protobuf.Payload)
+Reading = _reflection.GeneratedProtocolMessageType('Reading', (_message.Message,), dict(
+  DESCRIPTOR = _READING,
+  __module__ = 'sparkplug_b_pb2'
+  # @@protoc_insertion_point(class_scope:sparkplug.Reading)
   ))
-_sym_db.RegisterMessage(Payload)
-_sym_db.RegisterMessage(Payload.Template)
-_sym_db.RegisterMessage(Payload.Template.Parameter)
-_sym_db.RegisterMessage(Payload.Template.Parameter.ParameterValueExtension)
-_sym_db.RegisterMessage(Payload.DataSet)
-_sym_db.RegisterMessage(Payload.DataSet.DataSetValue)
-_sym_db.RegisterMessage(Payload.DataSet.DataSetValue.DataSetValueExtension)
-_sym_db.RegisterMessage(Payload.DataSet.Row)
-_sym_db.RegisterMessage(Payload.PropertyValue)
-_sym_db.RegisterMessage(Payload.PropertyValue.PropertyValueExtension)
-_sym_db.RegisterMessage(Payload.PropertySet)
-_sym_db.RegisterMessage(Payload.PropertySetList)
-_sym_db.RegisterMessage(Payload.MetaData)
-_sym_db.RegisterMessage(Payload.Metric)
-_sym_db.RegisterMessage(Payload.Metric.MetricValueExtension)
+_sym_db.RegisterMessage(Reading)
+
+ReadingValue = _reflection.GeneratedProtocolMessageType('ReadingValue', (_message.Message,), dict(
+  DESCRIPTOR = _READINGVALUE,
+  __module__ = 'sparkplug_b_pb2'
+  # @@protoc_insertion_point(class_scope:sparkplug.ReadingValue)
+  ))
+_sym_db.RegisterMessage(ReadingValue)
+
+ReadingsList = _reflection.GeneratedProtocolMessageType('ReadingsList', (_message.Message,), dict(
+  DESCRIPTOR = _READINGSLIST,
+  __module__ = 'sparkplug_b_pb2'
+  # @@protoc_insertion_point(class_scope:sparkplug.ReadingsList)
+  ))
+_sym_db.RegisterMessage(ReadingsList)
 
 
-DESCRIPTOR.has_options = True
-DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b('\n!com.cirruslink.sparkplug.protobufB\017SparkplugBProto'))
 # @@protoc_insertion_point(module_scope)


### PR DESCRIPTION
To get this plugin in stable mode, Protbuf message structure only with `string, int, float` type. For other types created a 9198 ticket.
